### PR TITLE
[STYLE] 공통 최대 너비 변수로 레이아웃 일관성 정리

### DIFF
--- a/apps/react/src/components/BottomNav.tsx
+++ b/apps/react/src/components/BottomNav.tsx
@@ -41,7 +41,7 @@ export function BottomNav() {
 
   return (
     <nav
-      className="fixed bottom-0 left-1/2 z-100 flex min-h-(--bottom-nav-h) w-full max-w-[512px] -translate-x-1/2 items-center justify-around gap-1 border-t border-neutral-200 bg-white dark:border-white/10 dark:bg-neutral-900"
+      className="fixed bottom-0 left-1/2 z-100 flex min-h-(--bottom-nav-h) w-full max-w-(--common-max-width) -translate-x-1/2 items-center justify-around gap-1 border-t border-neutral-200 bg-white dark:border-white/10 dark:bg-neutral-900"
       style={{ paddingBottom: "max(12px, env(safe-area-inset-bottom))" }}
     >
       {TAB_ROUTES.map(({ to, label, IconActive, IconInactive }) => {

--- a/apps/react/src/components/BottomSheet.tsx
+++ b/apps/react/src/components/BottomSheet.tsx
@@ -39,7 +39,7 @@ export function BottomSheet({
     >
       <Drawer.Portal>
         <Drawer.Overlay className="fixed inset-0 z-100 bg-black/40" />
-        <Drawer.Content className="fixed bottom-0 left-0 right-0 z-100 flex flex-col rounded-t-[10px] bg-white max-h-[85vh] overflow-hidden">
+        <Drawer.Content className="fixed bottom-0 left-1/2 z-100 flex w-full max-w-(--common-max-width) -translate-x-1/2 flex-col overflow-hidden rounded-t-[10px] bg-white max-h-[85vh]">
           <Drawer.Title className="sr-only">{sheetTitle}</Drawer.Title>
           <Drawer.Description className="sr-only">{sheetDescription}</Drawer.Description>
           <div className="mx-auto mt-4 h-1.5 w-12 shrink-0 rounded-full bg-neutral-20" />

--- a/apps/react/src/routes/__root.tsx
+++ b/apps/react/src/routes/__root.tsx
@@ -88,7 +88,7 @@ function RootComponent() {
           backgroundColor: topSafeAreaColor,
         }}
       />
-      <div className="no-bounce-scroll mx-auto flex h-screen w-full max-w-[512px] flex-col overflow-hidden bg-white">
+      <div className="no-bounce-scroll mx-auto flex h-screen w-full max-w-(--common-max-width) flex-col overflow-hidden bg-white">
         <main className="no-bounce-scroll relative min-h-0 w-full flex-1 overflow-hidden">
           <NavigationTransitionProvider>
             <TransitionViewport>


### PR DESCRIPTION
## 📌 반영 브랜치
style/13 -> main

## 📋 내용
### 💻 스크린
- [x] BottomNav, BottomSheet, 루트 레이아웃의 최대 너비를 `--common-max-width`로 통일
- [ ] 추가 화면별 최대 너비 정책 점검

---

### 💻 스크린
- [x] BottomSheet를 공통 최대 너비 컨테이너 기준으로 정렬
- [ ] 모바일/태블릿 뷰포트별 시각 검수

## 🚨 유의 사항
- [ ] 다크모드 포함 주요 화면의 레이아웃 깨짐 여부 확인

Closes #13

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 스타일

* 하단 네비게이션 및 시트 컴포넌트의 레이아웃이 개선되었습니다.
* 전체 콘텐츠 컨테이너의 너비 제약이 일관성 있게 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->