### PR TITLE
[FEAT] 웹뷰 Safe Area 및 탭 전환 UX 개선

### DIFF
--- a/apps/react/src/components/BottomNav.tsx
+++ b/apps/react/src/components/BottomNav.tsx
@@ -36,13 +36,17 @@ const TAB_ROUTES = [
   },
 ] as const;
 
-export function BottomNav() {
+interface BottomNavProps {
+  bottomPadding: string;
+}
+
+export function BottomNav({ bottomPadding }: BottomNavProps) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
 
   return (
     <nav
       className="fixed bottom-0 left-1/2 z-100 flex min-h-(--bottom-nav-h) w-full max-w-(--common-max-width) -translate-x-1/2 items-center justify-around gap-1 border-t border-neutral-200 bg-white"
-      style={{ paddingBottom: "max(12px, env(safe-area-inset-bottom))" }}
+      style={{ paddingBottom: bottomPadding }}
     >
       {TAB_ROUTES.map(({ to, label, IconActive, IconInactive }) => {
         const isActive = pathname === to;
@@ -52,6 +56,7 @@ export function BottomNav() {
             key={to}
             to={to}
             replace
+            state={{ transitionDirection: "none" }}
             className={`flex flex-1 flex-col items-center justify-center gap-2 py-2 no-underline transition-colors ${
               isActive ? "text-gray-dark" : "text-gray-medium"
             } hover:text-gray-dark`}

--- a/apps/react/src/components/PageHeader.tsx
+++ b/apps/react/src/components/PageHeader.tsx
@@ -174,6 +174,7 @@ export function PageHeader({
     <>
       <div
         ref={stickyRowRef}
+        data-page-header-sticky="true"
         className={`sticky top-0 z-20 bg-black ${searchTo == null && children == null ? "border-b border-neutral-200" : ""}`}
         style={{
           paddingLeft: "max(20px, env(safe-area-inset-left, 0px))",
@@ -203,6 +204,24 @@ export function PageHeader({
               {icons.map(({ to, ariaLabel, IconGray, IconWhite }) => {
                 const isActive = pathname === to;
                 const Icon = isActive ? IconWhite : IconGray;
+                if (to === MY_PAGE_ALARMS) {
+                  return (
+                    <Link
+                      key={to}
+                      to={to}
+                      search={{ from: pathname }}
+                      state={{ transitionDirection: "forward" }}
+                      onClick={(e: React.MouseEvent<HTMLAnchorElement>) =>
+                        handleMemberOnlyIconClick(e, to)
+                      }
+                      className="rounded-full p-3 transition-opacity hover:opacity-80 active:opacity-70"
+                      aria-label={ariaLabel}
+                    >
+                      <Icon className="h-6 w-6 shrink-0" aria-hidden />
+                    </Link>
+                  );
+                }
+
                 return (
                   <Link
                     key={to}
@@ -239,7 +258,7 @@ export function PageHeader({
               className="flex items-center gap-0.5 rounded-lg border border-neutral-300 bg-neutral-50 p-3 text-sm font-medium text-neutral-500 transition-colors hover:bg-neutral-100"
             >
               <SearchIcon className="h-5 w-5 shrink-0" aria-hidden />
-              <span>{searchPlaceholder}</span>
+              <span className="truncate">{searchPlaceholder}</span>
             </Link>
           ) : null}
           {children != null ? (

--- a/apps/react/src/routes/__root.tsx
+++ b/apps/react/src/routes/__root.tsx
@@ -1,13 +1,15 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { createRootRoute, useRouterState } from "@tanstack/react-router";
 import { Toaster } from "sonner";
 import { BottomNav } from "../components/BottomNav";
 import { bridge } from "@/bridge";
-import { getAccessToken } from "@/api/axios";
+import { canUseMemberOnlyApi, getAccessToken } from "@/api/axios";
 import { StackedOutlet } from "@/shared/ui/stacked-outlet";
 import { TransitionViewport } from "@/shared/ui/transition-viewport";
+import { getBottomSafeAreaPadding, getTopSafeAreaInset } from "@/utils/safeArea";
 
 const BOTTOM_NAV_PATHS = ["/space", "/announcement", "/reservation", "/mypage"];
+const PRE_AUTH_PATH_PREFIXES = ["/", "/login", "/signup"];
 
 /** 상단 safe area를 검정으로 할 경로 (해당 경로 및 하위 경로 포함) */
 const TOP_SAFE_AREA_BLACK_PREFIXES = ["/space", "/announcement"];
@@ -32,6 +34,13 @@ function isTopSafeAreaBlack(pathname: string): boolean {
   );
 }
 
+function isPreAuthPath(pathname: string): boolean {
+  if (pathname === "/") return true;
+  return PRE_AUTH_PATH_PREFIXES.some((prefix) =>
+    prefix === "/" ? false : pathname === prefix || pathname.startsWith(prefix + "/")
+  );
+}
+
 export const Route = createRootRoute({
   component: RootComponent,
 });
@@ -39,7 +48,12 @@ export const Route = createRootRoute({
 function RootComponent() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const showBottomNav = BOTTOM_NAV_PATHS.includes(pathname);
+  const shouldGuardAuthBack = showBottomNav && canUseMemberOnlyApi();
+  const latestPathRef = useRef(pathname);
+  const latestUrlRef = useRef("");
   const topSafeAreaColor = isTopSafeAreaBlack(pathname) ? "#000000" : "#FFFFFF";
+  const topSafeAreaInset = getTopSafeAreaInset();
+  const bottomNavPadding = getBottomSafeAreaPadding("12px");
 
   // Expo WebView 내부일 때 네이티브 상단 SafeArea 색상 동기화
   useEffect(() => {
@@ -50,6 +64,34 @@ function RootComponent() {
       bridge.setTopSafeAreaColor(topSafeAreaColor).catch(() => {});
     }
   }, [topSafeAreaColor]);
+
+  useEffect(() => {
+    if (!shouldGuardAuthBack || typeof window === "undefined") return;
+
+    latestPathRef.current = pathname;
+    latestUrlRef.current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  }, [pathname, shouldGuardAuthBack]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handlePopState = () => {
+      if (!canUseMemberOnlyApi()) return;
+
+      const previousPath = latestPathRef.current;
+      const previousUrl = latestUrlRef.current;
+      const nextPath = window.location.pathname;
+      if (!BOTTOM_NAV_PATHS.includes(previousPath) || !isPreAuthPath(nextPath)) return;
+
+      const nextState =
+        window.history.state && typeof window.history.state === "object" ? window.history.state : {};
+
+      window.history.pushState(nextState, "", previousUrl);
+    };
+
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, []);
 
   // 앱에 AccessToken 동기화 (FCM 토큰 등록 등에 사용)
   useEffect(() => {
@@ -86,8 +128,8 @@ function RootComponent() {
       <div
         aria-hidden
         style={{
-          height: "env(safe-area-inset-top, 0px)",
-          minHeight: "env(safe-area-inset-top, 0px)",
+          height: topSafeAreaInset,
+          minHeight: topSafeAreaInset,
           backgroundColor: topSafeAreaColor,
         }}
       />
@@ -100,11 +142,11 @@ function RootComponent() {
         {showBottomNav && (
           <div
             className="min-h-(--bottom-nav-h) shrink-0"
-            style={{ paddingBottom: "max(12px, env(safe-area-inset-bottom))" }}
+            style={{ paddingBottom: bottomNavPadding }}
             aria-hidden
           />
         )}
-        {showBottomNav && <BottomNav />}
+        {showBottomNav && <BottomNav bottomPadding={bottomNavPadding} />}
       </div>
       <Toaster position="bottom-center" richColors closeButton={false} />
     </div>

--- a/apps/react/src/routes/alarms/index.tsx
+++ b/apps/react/src/routes/alarms/index.tsx
@@ -7,12 +7,20 @@ import type { AlarmItem } from "@/api";
 import { backWithHistory } from "@/shared/navigation/back";
 
 export const Route = createFileRoute("/alarms/")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    from: typeof search.from === "string" ? search.from : undefined,
+  }),
   component: AlarmsPage,
 });
+
+function isAlarmEntryPath(path: string): path is "/space" | "/announcement" | "/reservation" | "/mypage" {
+  return path === "/space" || path === "/announcement" || path === "/reservation" || path === "/mypage";
+}
 
 function AlarmsPage() {
   const navigate = useNavigate();
   const router = useRouter();
+  const search = Route.useSearch();
   const queryClient = useQueryClient();
   const isMemberOnlyAllowed = canUseMemberOnlyApi();
 
@@ -52,7 +60,8 @@ function AlarmsPage() {
     if (window.history.length > 1) {
       backWithHistory(router);
     } else {
-      navigate({ to: "/mypage", state: { transitionDirection: "back" } });
+      const fallbackTo = isAlarmEntryPath(search.from ?? "") ? search.from : "/mypage";
+      navigate({ to: fallbackTo, state: { transitionDirection: "back" } });
     }
   };
 

--- a/apps/react/src/routes/announcement/$id.tsx
+++ b/apps/react/src/routes/announcement/$id.tsx
@@ -8,6 +8,7 @@ import { canUseMemberOnlyApi } from "@/api/axios";
 import { ImageCarousel } from "@/components/ImageCarousel";
 import { useLoginRequiredModal } from "@/hooks/useLoginRequiredModal";
 import { bridge } from "@/bridge";
+import { getBottomSafeAreaPadding, getTopSafeAreaInset } from "@/utils/safeArea";
 import ArrowRightWhiteIcon from "@/assets/icons/Arrow/right-white.svg?react";
 import LikeLightgray from "@/assets/icons/like/like-lightgray.svg?react";
 import LikePurple from "@/assets/icons/like/like-purple.svg?react";
@@ -146,11 +147,13 @@ function AnnouncementDetailPage() {
   const hasAnnouncementPage = announcementPageUrl.length > 0;
   const locationText = [data.city, data.district].filter(Boolean).join("") || "-";
   const dateRange = `${formatDate(data.recruitmentStartAt)} ~ ${formatDate(data.recruitmentEndAt)}`;
+  const topInset = getTopSafeAreaInset();
+  const bottomActionPadding = getBottomSafeAreaPadding("12px");
 
   return (
     <div
       className="fixed top-0 bottom-0 left-1/2 flex w-full max-w-(--common-max-width) -translate-x-1/2 flex-col overflow-hidden bg-white"
-      style={{ top: "env(safe-area-inset-top, 0px)" }}
+      style={{ top: topInset }}
     >
       {/* 헤더 */}
       <div className="shrink-0 bg-dice-black">
@@ -211,7 +214,7 @@ function AnnouncementDetailPage() {
         className="shrink-0 border-t border-stroke-eee bg-dice-white px-5"
         style={{
           paddingTop: "12px",
-          paddingBottom: "max(12px, env(safe-area-inset-bottom, 0px))",
+          paddingBottom: bottomActionPadding,
         }}
       >
         <button

--- a/apps/react/src/routes/messages/$roomId.tsx
+++ b/apps/react/src/routes/messages/$roomId.tsx
@@ -15,6 +15,7 @@ import { canUseMemberOnlyApi } from "@/api/axios";
 import { getDummyMessageDetail, DUMMY_MESSAGE_ROOMS } from "@/api/message/dummy";
 import type { MessageData } from "@/api";
 import { backWithHistory } from "@/shared/navigation/back";
+import { getBottomSafeAreaPadding, getTopSafeAreaPadding } from "@/utils/safeArea";
 
 const REPORT_REASONS = [
   "스팸/광고",
@@ -90,6 +91,8 @@ function MessageRoomPage() {
   const [reportSheetOpen, setReportSheetOpen] = useState(false);
   const [selectedReportReason, setSelectedReportReason] = useState<string | null>(null);
   const [reporting, setReporting] = useState(false);
+  const messageListTopPadding = `calc(${getTopSafeAreaPadding("12px")} + 48px + 12px + 12px)`;
+  const messageInputBottomPadding = getBottomSafeAreaPadding("12px");
 
   const { data: rooms } = useQuery({
     queryKey: queryKeys.message.list,
@@ -243,7 +246,7 @@ function MessageRoomPage() {
       <div
         className="px-5 pb-1"
         style={{
-          paddingTop: "calc(max(12px, env(safe-area-inset-top, 0px)) + 48px + 12px + 12px)",
+          paddingTop: messageListTopPadding,
         }}
       >
         <p className="typo-caption1 rounded-lg p-4 bg-bg-white mb-6 text-center leading-relaxed text-gray-deep">
@@ -291,7 +294,7 @@ function MessageRoomPage() {
       <div
         className="fixed bottom-0 left-1/2 z-10 w-full max-w-(--common-max-width) -translate-x-1/2 border-t border-neutral-200 bg-dice-white"
         style={{
-          paddingBottom: "max(12px, env(safe-area-inset-bottom, 0px))",
+          paddingBottom: messageInputBottomPadding,
           paddingLeft: "20px",
           paddingRight: "20px",
           paddingTop: "12px",

--- a/apps/react/src/routes/mypage/index.tsx
+++ b/apps/react/src/routes/mypage/index.tsx
@@ -124,7 +124,7 @@ function MypagePage() {
                       />
                       {bgImage ? <div className="absolute inset-0 bg-(--dim-basic)" /> : null}
                       <div className="relative flex flex-col gap-3 p-1">
-                        <div className="block bg-black py-4 pl-5 space-y-4">
+                        <div className={`block py-4 pl-5 space-y-4 ${bgImage ? "bg-transparent" : "bg-black"}`}>
                           <p className="typo-h1 text-white">{primaryBrand.name}</p>
                           {primaryBrand.description ? (
                             <p className="typo-body2 text-gray-light line-clamp-2">

--- a/apps/react/src/routes/mypage/withdraw.tsx
+++ b/apps/react/src/routes/mypage/withdraw.tsx
@@ -4,6 +4,7 @@ import ArrowDownIcon from "@/assets/icons/Arrow/down.svg?react";
 import { BackHeader } from "@/components/BackHeader";
 import { BottomSheet } from "@/components/BottomSheet";
 import { backWithHistory } from "@/shared/navigation/back";
+import { getBottomSafeAreaPadding, getBottomSafeAreaSpacer } from "@/utils/safeArea";
 
 const WITHDRAWAL_REASONS = [
   "앱 방문을 잘 하지 않아요",
@@ -23,6 +24,8 @@ function MypageWithdrawPage() {
   const router = useRouter();
   const [reasonSheetOpen, setReasonSheetOpen] = useState(false);
   const [selectedReason, setSelectedReason] = useState<string | null>(null);
+  const bottomActionSpacer = getBottomSafeAreaSpacer("100px");
+  const bottomActionPadding = getBottomSafeAreaPadding("20px");
 
   const handleBack = () => {
     if (window.history.length > 1) {
@@ -42,7 +45,7 @@ function MypageWithdrawPage() {
       <div aria-hidden style={{ minHeight: 48 }} />
       <div
         className="px-5 pt-8 space-y-8"
-        style={{ paddingBottom: "calc(100px + env(safe-area-inset-bottom))" }}
+        style={{ paddingBottom: bottomActionSpacer }}
       >
         <section className="space-y-2">
           <h2 className="typo-subtitle2 whitespace-pre-line text-(--dice-black)">
@@ -114,7 +117,7 @@ function MypageWithdrawPage() {
       {/* 하단 고정 버튼 */}
       <div
         className="fixed bottom-0 left-0 right-0 z-10 mx-auto max-w-sm gap-3 bg-dice-white px-5 pt-4"
-        style={{ paddingBottom: "max(20px, env(safe-area-inset-bottom))" }}
+        style={{ paddingBottom: bottomActionPadding }}
       >
         <div className="flex gap-3">
           <button

--- a/apps/react/src/routes/reservation/apply.info.tsx
+++ b/apps/react/src/routes/reservation/apply.info.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { BackHeader } from "@/components/BackHeader";
 import { createReservation, queryKeys, uploadImageList } from "@/api";
 import { backWithHistory } from "@/shared/navigation/back";
+import { getBottomSafeAreaPadding, getBottomSafeAreaSpacer } from "@/utils/safeArea";
 
 export const Route = createFileRoute("/reservation/apply/info")({
   validateSearch: (search: Record<string, unknown>) => ({
@@ -30,6 +31,8 @@ function ReservationApplyInfoPage() {
   const [eventName, setEventName] = useState("");
   const [eventContent, setEventContent] = useState("");
   const [extraRequest, setExtraRequest] = useState("");
+  const bottomActionSpacer = getBottomSafeAreaSpacer("100px");
+  const bottomActionPadding = getBottomSafeAreaPadding("20px");
 
   const createMutation = useMutation({
     mutationFn: createReservation,
@@ -157,12 +160,12 @@ function ReservationApplyInfoPage() {
           </section>
         </div>
         {/* 하단 고정 버튼에 가리지 않도록 스크롤 여백 */}
-        <div aria-hidden style={{ minHeight: "calc(100px + env(safe-area-inset-bottom))" }} />
+        <div aria-hidden style={{ minHeight: bottomActionSpacer }} />
       </div>
 
       <div
         className="fixed bottom-0 left-0 right-0 z-10 mx-auto w-full max-w-(--common-max-width) bg-dice-white px-5 pt-4"
-        style={{ paddingBottom: "max(20px, env(safe-area-inset-bottom))" }}
+        style={{ paddingBottom: bottomActionPadding }}
       >
         <button
           type="button"

--- a/apps/react/src/routes/reservation/apply.tsx
+++ b/apps/react/src/routes/reservation/apply.tsx
@@ -9,6 +9,7 @@ import { useQuery } from "@tanstack/react-query";
 import { BackHeader } from "@/components/BackHeader";
 import { getMyBrandInfo, queryKeys } from "@/api";
 import { backWithHistory } from "@/shared/navigation/back";
+import { getBottomSafeAreaPadding, getBottomSafeAreaSpacer } from "@/utils/safeArea";
 
 export const Route = createFileRoute("/reservation/apply")({
   validateSearch: (search: Record<string, unknown>) => ({
@@ -57,6 +58,8 @@ function ReservationApplyPage() {
   };
 
   const imageUrls = brand ? [brand.logoUrl, ...(brand.imageUrls ?? [])].filter(Boolean) : [];
+  const bottomActionSpacer = getBottomSafeAreaSpacer("100px");
+  const bottomActionPadding = getBottomSafeAreaPadding("20px");
 
   return (
     <div className="min-h-screen bg-dice-white">
@@ -115,12 +118,12 @@ function ReservationApplyPage() {
           </div>
         )}
         {/* 하단 고정 버튼에 가리지 않도록 스크롤 여백 */}
-        <div aria-hidden style={{ minHeight: "calc(100px + env(safe-area-inset-bottom))" }} />
+        <div aria-hidden style={{ minHeight: bottomActionSpacer }} />
       </div>
 
       <div
         className="fixed bottom-0 left-0 right-0 z-10 mx-auto w-full max-w-(--common-max-width) bg-dice-white px-5 pt-4"
-        style={{ paddingBottom: "max(20px, env(safe-area-inset-bottom))" }}
+        style={{ paddingBottom: bottomActionPadding }}
       >
         <button
           type="button"

--- a/apps/react/src/routes/reservation/index.tsx
+++ b/apps/react/src/routes/reservation/index.tsx
@@ -45,6 +45,7 @@ function ReservationPage() {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
   const [activeStatus, setActiveStatus] = useState<ReservationStatus>("PENDING");
+  const [pageHeaderHeight, setPageHeaderHeight] = useState(57);
   const isMemberOnlyAllowed = canUseMemberOnlyApi();
   const prefersReducedMotion = useReducedMotion() ?? false;
 
@@ -106,6 +107,25 @@ function ReservationPage() {
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
+  useEffect(() => {
+    const header = scrollContainerRef.current?.querySelector<HTMLElement>("[data-page-header-sticky='true']");
+    if (!header) return;
+
+    const updatePageHeaderHeight = () => {
+      setPageHeaderHeight(header.getBoundingClientRect().height);
+    };
+
+    updatePageHeaderHeight();
+
+    const resizeObserver = new ResizeObserver(() => {
+      updatePageHeaderHeight();
+    });
+
+    resizeObserver.observe(header);
+
+    return () => resizeObserver.disconnect();
+  }, []);
+
   const content = (data?.pages.flatMap((p) => p.content) ?? []) as ReservationItem[];
   const emptyMessage = EMPTY_MESSAGE_BY_STATUS[activeStatus];
 
@@ -120,7 +140,10 @@ function ReservationPage() {
 
         {isMemberOnlyAllowed ? (
           <>
-            <div className="sticky top-[81px] z-10 flex border-b border-neutral-200 bg-bg-light-gray">
+            <div
+              className="sticky z-10 flex border-b border-neutral-200 bg-bg-light-gray"
+              style={{ top: `${pageHeaderHeight}px` }}
+            >
               {TAB_STATUSES.map(({ key, label }) => (
                 <button
                   key={key}

--- a/apps/react/src/routes/signup/brand-profile.tsx
+++ b/apps/react/src/routes/signup/brand-profile.tsx
@@ -15,6 +15,7 @@ import PlusIcon from "@/assets/icons/Plus/plus.svg?react";
 import XIcon from "@/assets/icons/Onboarding/round-x.svg?react";
 import FemaleIcon from "@/assets/icons/Target/female.svg?react";
 import MaleIcon from "@/assets/icons/Target/male.svg?react";
+import { getBottomSafeAreaPadding } from "@/utils/safeArea";
 
 export const Route = createFileRoute("/signup/brand-profile")({
   component: BrandProfilePage,
@@ -149,6 +150,7 @@ function BrandProfilePage() {
   })();
 
   const isFormValid = targetGender.length > 0 && targetAgeGroup.length > 0;
+  const bottomActionPadding = getBottomSafeAreaPadding("20px");
 
   return (
     <div className="relative mx-auto">
@@ -345,7 +347,7 @@ function BrandProfilePage() {
 
       <div
         className="fixed bottom-0 left-0 right-0 z-10 mx-auto w-full max-w-(--common-max-width) bg-white px-5 pt-1"
-        style={{ paddingBottom: "max(20px, env(safe-area-inset-bottom))" }}
+        style={{ paddingBottom: bottomActionPadding }}
       >
         <button
           type="submit"

--- a/apps/react/src/routes/signup/index.tsx
+++ b/apps/react/src/routes/signup/index.tsx
@@ -21,6 +21,7 @@ import {
   validatePhone,
 } from "@/lib/signupValidation";
 import { backWithHistory } from "@/shared/navigation/back";
+import { getBottomSafeAreaPadding } from "@/utils/safeArea";
 
 export const Route = createFileRoute("/signup/")({
   validateSearch: (search: Record<string, unknown>) => ({
@@ -149,6 +150,7 @@ function SignupPage() {
 
   const inputBase =
     "typo-body2 w-full appearance-none rounded-lg border bg-white px-4 py-3 text-[16px] text-(--gray-dark) placeholder:text-(--gray-light) focus:outline-none focus:ring-1";
+  const bottomActionPadding = getBottomSafeAreaPadding("20px");
 
   const getBorderByMessageColor = (messageColor: MessageColor) => {
     switch (messageColor) {
@@ -396,7 +398,7 @@ function SignupPage() {
 
       <div
         className="fixed bottom-0 left-0 right-0 z-10 mx-auto w-full max-w-(--common-max-width) bg-white px-5 pt-1"
-        style={{ paddingBottom: "max(20px, env(safe-area-inset-bottom))" }}
+        style={{ paddingBottom: bottomActionPadding }}
       >
         <button
           type="submit"

--- a/apps/react/src/routes/space/$id.map.tsx
+++ b/apps/react/src/routes/space/$id.map.tsx
@@ -6,6 +6,7 @@ import { backWithHistory } from "@/shared/navigation/back";
 import { getSpaceDetailData, queryKeys } from "@/api";
 import { getDummySpaceDetail } from "@/api/space/dummy";
 import { NaverMap } from "@/components/NaverMap";
+import { getBottomSafeAreaInset, getTopSafeAreaInset } from "@/utils/safeArea";
 
 export const Route = createFileRoute("/space/$id/map")({
   component: SpaceMapPage,
@@ -96,6 +97,8 @@ function SpaceMapPage() {
     : data.address
       ? `nmap://search?query=${encodeURIComponent(data.address)}&appname=${appName}`
       : "";
+  const safeTopPadding = getTopSafeAreaInset();
+  const safeBottomPadding = getBottomSafeAreaInset();
 
   const handleOpenNaverMap = async () => {
     if (!browserUrl) return;
@@ -120,8 +123,8 @@ function SpaceMapPage() {
     <div
       className="fixed left-1/2 top-0 bottom-0 flex w-full max-w-(--common-max-width) -translate-x-1/2 flex-col overflow-hidden bg-dice-white"
       style={{
-        paddingTop: "env(safe-area-inset-top, 0px)",
-        paddingBottom: "env(safe-area-inset-bottom, 0px)",
+        paddingTop: safeTopPadding,
+        paddingBottom: safeBottomPadding,
       }}
     >
       {/* 상단 바 */}

--- a/apps/react/src/routes/space/$id.population.tsx
+++ b/apps/react/src/routes/space/$id.population.tsx
@@ -4,6 +4,7 @@ import ArrowRightIcon from "@/assets/icons/Arrow/right.svg?react";
 import { getSpaceDetailData, queryKeys } from "@/api";
 import { DUMMY_SPACE_POPULATION_ANALYSIS, getDummySpaceDetail } from "@/api/space/dummy";
 import { backWithHistory } from "@/shared/navigation/back";
+import { getBottomSafeAreaInset, getTopSafeAreaInset } from "@/utils/safeArea";
 
 export const Route = createFileRoute("/space/$id/population")({
   component: SpacePopulationPage,
@@ -110,6 +111,8 @@ function SpacePopulationPage() {
   const analysisSummary = detailData.analysis;
   const data = populationData;
   const hasPopulationData = data != null;
+  const topSafeAreaInset = getTopSafeAreaInset();
+  const bottomSafeAreaInset = getBottomSafeAreaInset();
 
   const menCounts = getSafeCounts(data?.ageGroupsCountMan, AGE_LABELS.length);
   const womenCounts = getSafeCounts(data?.ageGroupsCountWoman, AGE_LABELS.length);
@@ -143,8 +146,8 @@ function SpacePopulationPage() {
     <div
       className="fixed left-1/2 top-0 bottom-0 flex w-full max-w-(--common-max-width) -translate-x-1/2 flex-col overflow-hidden bg-dice-white"
       style={{
-        paddingTop: "env(safe-area-inset-top, 0px)",
-        paddingBottom: "env(safe-area-inset-bottom, 0px)",
+        paddingTop: topSafeAreaInset,
+        paddingBottom: bottomSafeAreaInset,
       }}
     >
       <header

--- a/apps/react/src/routes/space/$id.tsx
+++ b/apps/react/src/routes/space/$id.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/scrollStorage";
 import { useTabScrollStorage } from "@/hooks/useTabScrollStorage";
 import { m2ToPyeong } from "@/utils/sizeConversion";
+import { getBottomSafeAreaPadding, getTopSafeAreaInset } from "@/utils/safeArea";
 import PlaceIcon from "@/assets/place.svg?react";
 import MapIcon from "@/assets/map.svg?react";
 import DownArrowIcon from "@/assets/down-arrow.svg?react";
@@ -337,6 +338,8 @@ function SpaceDetailPage() {
   const facilityInfos = data.facilityInfos ?? [];
   const visibleFacilityInfos = facilitiesExpanded ? facilityInfos : facilityInfos.slice(0, 8);
   const tags = data.tags ?? [];
+  const topInset = getTopSafeAreaInset();
+  const bottomActionPadding = getBottomSafeAreaPadding("12px");
 
   const messageRoomId = data.messageRoomId;
   const reservationUnitPrice = data.discountRate > 0 ? data.discountPrice : data.pricePerDay;
@@ -347,14 +350,14 @@ function SpaceDetailPage() {
   return (
     <div
       className="no-bounce-scroll fixed left-1/2 bottom-0 flex w-full max-w-(--common-max-width) -translate-x-1/2 flex-col overflow-hidden bg-white"
-      style={{ top: "env(safe-area-inset-top, 0px)" }}
+      style={{ top: topInset }}
     >
       {/* 캐러셀 넘긴 뒤 보여줄 48px 상단 바 (레이아웃 영향 없이 fixed) */}
       <div
         className={`fixed top-0 left-1/2 z-20 flex h-[48px] w-full max-w-(--common-max-width) -translate-x-1/2 items-center bg-dice-black transition-opacity ${
           isPastCarousel ? "opacity-100" : "pointer-events-none opacity-0"
         }`}
-        style={{ top: "env(safe-area-inset-top, 0px)" }}
+        style={{ top: topInset }}
       >
         <button
           type="button"
@@ -375,7 +378,7 @@ function SpaceDetailPage() {
         }`}
         style={{
           left: 14,
-          top: "calc(10px + env(safe-area-inset-top, 0px))",
+          top: `calc(10px + ${topInset})`,
         }}
         aria-label="목록으로"
       >
@@ -637,7 +640,7 @@ function SpaceDetailPage() {
         className="flex shrink-0 items-center gap-3 border-t border-stroke-eee bg-dice-white px-5"
         style={{
           paddingTop: "12px",
-          paddingBottom: "max(12px, env(safe-area-inset-bottom, 0px))",
+          paddingBottom: bottomActionPadding,
         }}
       >
         <Link

--- a/apps/react/src/shared/ui/stacked-outlet.tsx
+++ b/apps/react/src/shared/ui/stacked-outlet.tsx
@@ -17,7 +17,9 @@ function isTabRootPath(path: string) {
 export function StackedOutlet() {
   const location = useRouterState({ select: (state) => state.location });
   const pathname = location.pathname;
-  const locationState = location.state as { transitionDirection?: "forward" | "back" } | undefined;
+  const locationState = location.state as
+    | { transitionDirection?: "forward" | "back" | "none" }
+    | undefined;
   const lastClearedPathRef = useRef<string | null>(null);
 
   const rawSession =
@@ -38,7 +40,7 @@ export function StackedOutlet() {
       ? "route-enter-back"
       : effectiveTransitionDirection === "forward"
         ? "route-enter-forward"
-        : isTabRootPath(pathname)
+        : effectiveTransitionDirection === "none" || isTabRootPath(pathname)
           ? "route-enter-none"
           : "route-enter-forward";
 

--- a/apps/react/src/styles/globals.css
+++ b/apps/react/src/styles/globals.css
@@ -14,6 +14,8 @@ body {
   overflow: hidden;
   overscroll-behavior-x: none;
   background-color: var(--bg-light-gray);
+  -webkit-text-size-adjust: none;
+  text-size-adjust: none;
 }
 
 :root {

--- a/apps/react/src/types/history.d.ts
+++ b/apps/react/src/types/history.d.ts
@@ -1,5 +1,5 @@
 declare module "@tanstack/history" {
   interface HistoryState {
-    transitionDirection?: "forward" | "back";
+    transitionDirection?: "forward" | "back" | "none";
   }
 }

--- a/apps/react/src/utils/platform.ts
+++ b/apps/react/src/utils/platform.ts
@@ -1,0 +1,5 @@
+export function isAndroid(): boolean {
+  if (typeof navigator === "undefined") return false;
+
+  return /Android/i.test(navigator.userAgent);
+}

--- a/apps/react/src/utils/safeArea.ts
+++ b/apps/react/src/utils/safeArea.ts
@@ -1,0 +1,21 @@
+import { isAndroid } from "@/utils/platform";
+
+export function getTopSafeAreaInset(): string {
+  return isAndroid() ? "0px" : "env(safe-area-inset-top, 0px)";
+}
+
+export function getBottomSafeAreaInset(): string {
+  return isAndroid() ? "0px" : "env(safe-area-inset-bottom, 0px)";
+}
+
+export function getBottomSafeAreaPadding(minPadding: string): string {
+  return isAndroid() ? minPadding : `max(${minPadding}, env(safe-area-inset-bottom, 0px))`;
+}
+
+export function getBottomSafeAreaSpacer(baseHeight: string): string {
+  return isAndroid() ? baseHeight : `calc(${baseHeight} + env(safe-area-inset-bottom, 0px))`;
+}
+
+export function getTopSafeAreaPadding(minPadding: string): string {
+  return isAndroid() ? minPadding : `max(${minPadding}, env(safe-area-inset-top, 0px))`;
+}


### PR DESCRIPTION
## 📌 반영 브랜치
feat/31 -> main

## 📋 내용
### 💻 웹뷰 Safe Area 대응
- [x] 공통 safe area 유틸을 추가하고 주요 화면의 상하단 여백 계산을 일관화했습니다.
- [x] 브라우저 텍스트 자동 확대를 막아 모바일 웹뷰 레이아웃 흔들림을 줄였습니다.

---

### 💻 하단 탭 · 알림 전환 UX 개선
- [x] 하단 탭 이동 시 전환 방향을 `none`으로 처리해 탭 전환 애니메이션을 보정했습니다.
- [x] 알림 화면 진입 경로를 보존해 이전 탭으로 자연스럽게 복귀할 수 있도록 했습니다.
- [x] 회원 전용 탭에서 인증 이전 화면으로의 뒤로가기를 방지해 앱형 탐색 흐름을 안정화했습니다.
- [x] 예약 화면의 sticky 헤더 위치를 동적으로 계산해 헤더 겹침을 줄였습니다.

## 🚨 유의 사항
- [ ] 모바일 웹과 Expo WebView에서 safe area 및 뒤로가기 동작 확인이 필요합니다.

Closes #31

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 안전 영역(Safe Area) 처리 개선으로 노치 및 동적 아일랜드 기기에서 레이아웃 최적화
  * 페이지 헤더 높이를 동적으로 측정하여 UI 배치 정확성 향상
  * 네비게이션 전환 애니메이션에 새로운 전환 방식 추가

* **개선 사항**
  * Android 기기에 특화된 안전 영역 처리 적용
  * 텍스트 크기 자동 조정 비활성화로 모바일 환경 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->