### PR TITLE
[FEAT] 브랜드 프로필 등록 흐름 및 배포 라우팅 개선

### DIFF
--- a/apps/expo/app.config.ts
+++ b/apps/expo/app.config.ts
@@ -10,7 +10,7 @@ const defineConfig: ExpoConfig = {
   version: "1.0.0",
   orientation: "portrait",
   icon: "./assets/images/icon.png",
-  scheme: "myapp",
+  scheme: "dice",
   userInterfaceStyle: "light",
   newArchEnabled: true,
   runtimeVersion: "1.0.0",
@@ -50,15 +50,15 @@ const defineConfig: ExpoConfig = {
     googleServicesFile: process.env.GOOGLE_SERVICES_INFO_PLIST ?? "./GoogleService-Info.plist",
   },
   android: {
-    package: "com.cmc.dice.minipop.expo",
-    versionCode: 2,
+    package: "com.minipop.dice2",
+    versionCode: 1,
     adaptiveIcon: {
       foregroundImage: "./assets/images/android_logo.png",
       backgroundColor: "#000000",
     },
     edgeToEdgeEnabled: true,
     predictiveBackGestureEnabled: false,
-    permissions: [],
+    permissions: ["POST_NOTIFICATIONS"],
     googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? "./google-services.json",
   },
   web: {

--- a/apps/react/src/api/axios.ts
+++ b/apps/react/src/api/axios.ts
@@ -1,4 +1,4 @@
-import axios, { type AxiosError, type InternalAxiosRequestConfig } from "axios";
+import axios, { AxiosHeaders, type AxiosError, type InternalAxiosRequestConfig } from "axios";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "/api";
 
@@ -16,9 +16,6 @@ const createBaseClient = () =>
   axios.create({
     baseURL: BASE_URL,
     timeout: 15_000,
-    headers: {
-      "Content-Type": "application/json",
-    },
   });
 
 /** 인증 필요 요청용 (Authorization 헤더 자동 첨부) */
@@ -26,6 +23,23 @@ export const apiClient = createBaseClient();
 
 /** 비인증 요청용 (로그인, 회원가입, 이메일/휴대폰 검증 등) */
 export const guestApiClient = createBaseClient();
+
+function normalizeRequestContentType(
+  config: InternalAxiosRequestConfig
+): InternalAxiosRequestConfig {
+  const headers =
+    config.headers instanceof AxiosHeaders ? config.headers : new AxiosHeaders(config.headers);
+
+  if (config.data instanceof FormData) {
+    // FormData는 브라우저/웹뷰가 boundary 포함 Content-Type을 자동 설정해야 함
+    headers.delete("Content-Type");
+  } else if (!headers.getContentType()) {
+    headers.setContentType("application/json");
+  }
+
+  config.headers = headers;
+  return config;
+}
 
 // 토큰 헬퍼 (웹→앱 브릿지 동기화 등에서 사용)
 export function getAccessToken(): string | null {
@@ -179,12 +193,18 @@ let refreshPromise: Promise<string> | null = null;
 // apiClient: 요청 인터셉터 — 토큰 첨부
 apiClient.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
+    normalizeRequestContentType(config);
     const token = getAccessToken();
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
     return config;
   },
+  (error) => Promise.reject(error)
+);
+
+guestApiClient.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => normalizeRequestContentType(config),
   (error) => Promise.reject(error)
 );
 

--- a/apps/react/src/routes/mypage/brand-profile.tsx
+++ b/apps/react/src/routes/mypage/brand-profile.tsx
@@ -2,8 +2,8 @@ import { isAxiosError } from "axios";
 import { createFileRoute, useNavigate, useRouter } from "@tanstack/react-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { forwardRef, useEffect, useRef, useState } from "react";
-import { getMyBrandInfo, updateBrand, queryKeys, uploadImageList } from "@/api";
-import type { UpdateBrandRequest } from "@/api";
+import { createBrand, getMyBrandInfo, updateBrand, queryKeys, uploadImageList } from "@/api";
+import type { CreateBrandRequest, UpdateBrandRequest } from "@/api";
 import type { BrandInfo } from "@/api";
 import {
   pickImageFromNative,
@@ -22,20 +22,14 @@ export const Route = createFileRoute("/mypage/brand-profile")({
   component: MypageBrandProfilePage,
 });
 
-/** 백엔드 미동작 시 사용하는 더미 브랜드 데이터 */
-const DUMMY_BRAND: BrandInfo = {
-  id: -1,
-  name: "나의 브랜드",
-  description: "트렌디한 라이프스타일을 제안하는 브랜드입니다.",
-  logoUrl: "https://picsum.photos/seed/brand1/400/400",
-  imageUrls: [
-    "https://picsum.photos/seed/brand2/400/400",
-    "https://picsum.photos/seed/brand3/400/400",
-    "https://picsum.photos/seed/brand4/400/400",
-    "https://picsum.photos/seed/brand5/400/400",
-  ],
-  targetGender: ["여성"],
-  targetAgeGroup: ["20대", "30대"],
+const EMPTY_BRAND: BrandInfo = {
+  id: 0,
+  name: "",
+  description: "",
+  logoUrl: "",
+  imageUrls: [],
+  targetGender: [],
+  targetAgeGroup: [],
 };
 
 const TARGET_GENDERS = [
@@ -176,11 +170,21 @@ const BrandProfileForm = forwardRef<
     setGalleryImageItems((prev) => prev.filter((_, i) => i !== index));
   };
 
-  const isDummy = brand.id === DUMMY_BRAND.id;
+  const isExistingBrand = brand.id > 0;
 
   const mutation = useMutation({
-    mutationFn: async ({ brandId, data }: { brandId: number; data: UpdateBrandRequest }) => {
-      await updateBrand(brandId, data);
+    mutationFn: async ({
+      brandId,
+      data,
+    }: {
+      brandId: number | null;
+      data: CreateBrandRequest | UpdateBrandRequest;
+    }) => {
+      if (brandId) {
+        await updateBrand(brandId, data);
+        return;
+      }
+      await createBrand(data);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.brand.myInfo });
@@ -193,21 +197,16 @@ const BrandProfileForm = forwardRef<
     if (isAxiosError(mutation.error)) {
       const msg =
         (mutation.error.response?.data as { message?: string })?.message ?? mutation.error.message;
-      return msg || "브랜드 프로필 수정에 실패했습니다.";
+      return msg || `브랜드 프로필 ${isExistingBrand ? "수정" : "등록"}에 실패했습니다.`;
     }
     return mutation.error instanceof Error
       ? mutation.error.message
-      : "브랜드 프로필 수정에 실패했습니다.";
+      : `브랜드 프로필 ${isExistingBrand ? "수정" : "등록"}에 실패했습니다.`;
   })();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!brand || mutation.isPending || !isFormValid) return;
-
-    if (isDummy) {
-      navigate({ to: "/mypage", state: { transitionDirection: "back" } });
-      return;
-    }
 
     let logoUrl = mainImageItem?.url ?? "";
     if (mainImageItem?.kind === "new") {
@@ -255,7 +254,7 @@ const BrandProfileForm = forwardRef<
       })
       .filter(Boolean);
 
-    const payload: UpdateBrandRequest = {
+    const payload: CreateBrandRequest | UpdateBrandRequest = {
       name: name.trim(),
       description: description.trim(),
       logoUrl,
@@ -265,7 +264,7 @@ const BrandProfileForm = forwardRef<
       ...(targetAgeGroup.length > 0 && { targetAgeGroup }),
     };
 
-    mutation.mutate({ brandId: brand.id, data: payload });
+    mutation.mutate({ brandId: isExistingBrand ? brand.id : null, data: payload });
   };
 
   const isFormValid = targetGender.length > 0 && targetAgeGroup.length > 0;
@@ -280,7 +279,9 @@ const BrandProfileForm = forwardRef<
     !areStringArraysEqual(targetAgeGroup, brand.targetAgeGroup ?? []) ||
     mainPreviewUrl !== initialMainImageUrl ||
     !areStringArraysEqual(galleryPreviewUrls, initialGalleryImageUrls);
-  const canSubmit = isFormValid && hasChanges && !mutation.isPending;
+  const canSubmit = isExistingBrand
+    ? isFormValid && hasChanges && !mutation.isPending
+    : isFormValid && !mutation.isPending;
 
   useEffect(() => {
     onCanSubmitChange?.(canSubmit);
@@ -313,14 +314,16 @@ const BrandProfileForm = forwardRef<
               {mainPreviewUrl ? (
                 <>
                   <img src={mainPreviewUrl} alt="" className="h-full w-full object-contain" />
-                  <span
-                    className="absolute inset-0 flex items-center justify-center bg-(--dim-basic)"
-                    aria-hidden
-                  >
-                    <CameraIcon className="h-8 w-8 text-white" />
-                  </span>
                 </>
               ) : null}
+              <span
+                className={`absolute inset-0 flex items-center justify-center ${
+                  mainPreviewUrl ? "bg-(--dim-basic)" : ""
+                }`}
+                aria-hidden
+              >
+                <CameraIcon className="h-8 w-8 text-white" />
+              </span>
             </button>
           </div>
 
@@ -473,7 +476,8 @@ function MypageBrandProfilePage() {
   });
 
   const brandList = Array.isArray(brands) ? brands : [];
-  const brand = brandList[0] ?? DUMMY_BRAND;
+  const brand = brandList[0] ?? EMPTY_BRAND;
+  const hasBrand = brandList.length > 0;
 
   const handleBack = () => {
     if (window.history.length > 1) {
@@ -499,7 +503,7 @@ function MypageBrandProfilePage() {
   return (
     <div className="min-h-screen bg-dice-white">
       <BackHeader
-        title="나의 브랜드 프로필 편집"
+        title={hasBrand ? "나의 브랜드 프로필 편집" : "나의 브랜드 프로필 등록"}
         onBack={handleBack}
         rightSlot={
           <button

--- a/apps/react/src/routes/mypage/index.tsx
+++ b/apps/react/src/routes/mypage/index.tsx
@@ -94,14 +94,16 @@ function MypagePage() {
         {/* 내 브랜드 정보: EditIcon + 브랜드 콘텐츠 하나의 섹션 */}
         <section className="mb-1.5">
           <div className="flex flex-col">
-            <Link
-              to="/mypage/brand-profile"
-              state={{ transitionDirection: "forward" }}
-              onClick={handleMemberOnlyButtonClick}
-              className="flex justify-end bg-dice-black p-3"
-            >
-              <EditIcon className="size-6" aria-hidden />
-            </Link>
+            <div className="flex justify-end bg-dice-black p-3">
+              <Link
+                to="/mypage/brand-profile"
+                state={{ transitionDirection: "forward" }}
+                onClick={handleMemberOnlyButtonClick}
+                className="inline-flex"
+              >
+                <EditIcon className="size-6" aria-hidden />
+              </Link>
+            </div>
             {primaryBrand ? (
               <ul className="flex flex-col gap-1">
                 {(() => {
@@ -116,7 +118,7 @@ function MypagePage() {
                   return (
                     <li
                       key={primaryBrand.id}
-                      className="relative overflow-hidden bg-(--gray-light)"
+                      className="relative min-h-[211px] overflow-hidden bg-(--gray-light)"
                     >
                       <div
                         className="absolute inset-0 bg-cover bg-center"
@@ -124,7 +126,9 @@ function MypagePage() {
                       />
                       {bgImage ? <div className="absolute inset-0 bg-(--dim-basic)" /> : null}
                       <div className="relative flex flex-col gap-3 p-1">
-                        <div className={`block py-4 pl-5 space-y-4 ${bgImage ? "bg-transparent" : "bg-black"}`}>
+                        <div
+                          className={`block py-4 pl-5 space-y-4 ${bgImage ? "bg-transparent" : "bg-black"}`}
+                        >
                           <p className="typo-h1 text-white">{primaryBrand.name}</p>
                           {primaryBrand.description ? (
                             <p className="typo-body2 text-gray-light line-clamp-2">
@@ -159,7 +163,7 @@ function MypagePage() {
                 })()}
               </ul>
             ) : (
-              <div className="block bg-black py-4 pl-5 space-y-4">
+              <div className="block min-h-[211px] bg-black py-4 pl-5 space-y-4">
                 <p className="typo-h1 text-white pr-5">브랜드 프로필을 작성해주세요</p>
                 <p className="typo-body2 text-gray-light pr-5">
                   팝업 공간을 대여해주는 호스트와 신뢰할 수 있는 거래를 위해 브랜드를 1~2문장으로

--- a/apps/react/vercel.json
+++ b/apps/react/vercel.json
@@ -2,5 +2,11 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm run build",
   "outputDirectory": "dist",
-  "installCommand": "pnpm install"
+  "installCommand": "pnpm install",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,11 @@
   "buildCommand": "pnpm -w run react:build",
   "outputDirectory": "apps/react/dist",
   "installCommand": "pnpm install",
-  "framework": null
+  "framework": null,
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
 }


### PR DESCRIPTION
## 📌 반영 브랜치
feat/33 -> main

## 📋 내용
### 💻 스크린
- [x] 브랜드 프로필이 없을 때 등록 화면과 생성 API 흐름을 연결했습니다.
- [x] FormData 업로드 요청의 Content-Type 처리를 보완했습니다.
- [ ] 스테이징 환경에서 브랜드 등록 플로우를 실사용 기준으로 재확인합니다.

---

### 💻 스크린
- [x] Vercel SPA 라우팅 재작성 규칙을 추가했습니다.
- [x] Expo 스킴과 안드로이드 패키지명, 알림 권한 설정을 정비했습니다.
- [ ] 배포 및 앱 빌드 환경에서 설정 반영 여부를 확인합니다.

## 🚨 유의 사항
- [ ] 브랜드 생성 API와 이미지 업로드를 스테이징 환경에서 검증할 필요가 있습니다.
- [ ] Vercel 배포 후 새로고침 및 직접 URL 진입 동작을 확인해야 합니다.

Closes #33

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 브랜드 프로필 신규 등록 기능 추가
  * Android 알림 권한 지원

* **개선사항**
  * 브랜드 프로필 섹션 레이아웃 최적화
  * 요청 헤더 처리 개선
  * 단일 페이지 애플리케이션 라우팅 지원 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->